### PR TITLE
Fix regex handling for result parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,9 +141,12 @@ Return ONLY the article text — no commentary, no prefixes.` ;
       catch{return u}
     };
 
+    const escapeRegex = s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
     const grab = (tag, txt)=>{
-      const m = txt.match(new RegExp("\\[?"+tag+"\\]?:\\s*([\\s\\S]*?)(?=\\n\\[|$)","i"));
-      return m?m[1].trim():"";
+      const safe = escapeRegex(tag);
+      const m = txt.match(new RegExp(`\\[?${safe}\\]?:\\s*([\\s\\S]*?)(?=\\n\\[|$)`, "i"));
+      return m ? m[1].trim() : "";
     };
 
     /* === GEMINI CALL === */


### PR DESCRIPTION
## Summary
- handle special characters in `grab` helper

## Testing
- `node -e "const grab=(tag,txt)=>{const esc=s=>s.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');const m=txt.match(new RegExp(`\\[?${esc(tag)}\\]?:\\s*([\\s\\S]*?)(?=\\n\\[|$)`,`i`));console.log(grab('a.b','[a.b]: c'));}"`

------
https://chatgpt.com/codex/tasks/task_e_68558b75e82c832b9797be9a5eb83f34